### PR TITLE
Require API key header for address derivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cd network-enclave
 The service requires the following environment variables:
 
 - `BIP32_SEED` - Hex-encoded seed for the BIP32 master key (mandatory)
-- `API_KEY` - API key for protected endpoints (if not set, protected endpoints will be inaccessible)
+- `ENCLAVE_API_KEY` - API key for protected endpoints (if not set, protected endpoints will reject requests)
 - `RUST_LOG` - Log level (e.g., info, debug, warn) - defaults to info
 
 ### Build and Run
@@ -41,12 +41,12 @@ The service requires the following environment variables:
 cargo build --release
 
 # run
-BIP32_SEED=000102030405060708090a0b0c0d0e0f API_KEY=your_api_key cargo run --release
+BIP32_SEED=000102030405060708090a0b0c0d0e0f ENCLAVE_API_KEY=your_api_key cargo run --release
 ```
 or if you have Just installed:
 
 ```sh
-BIP32_SEED=000102030405060708090a0b0c0d0e0f API_KEY=your_api_key just run
+BIP32_SEED=000102030405060708090a0b0c0d0e0f ENCLAVE_API_KEY=your_api_key just run
 ```
 
 ### Command-Line Arguments
@@ -59,16 +59,17 @@ The service supports the following command-line arguments:
 
 Example with custom arguments:
 ```
-BIP32_SEED=000102030405060708090a0b0c0d0e0f API_KEY=your_api_key cargo run --release -- --host 0.0.0.0 --port 8080 --network regtest
+BIP32_SEED=000102030405060708090a0b0c0d0e0f ENCLAVE_API_KEY=your_api_key cargo run --release -- --host 0.0.0.0 --port 8080 --network regtest
 ```
 
 ## API Endpoints
 
-### 1. Derive Bitcoin Address (Public)
-Derives a Bitcoin address from an Ethereum address.
+### 1. Derive Bitcoin Address (Protected)
+Derives a Bitcoin address from an Ethereum address. Requires the `X-API-Key` header.
 ```sh
 curl -X POST http://localhost:5555/derive_address \
   -H "Content-Type: application/json" \
+  -H "X-API-Key: your_api_key" \
   -d '{"ethereum_address": "0xF9F6608792F3efC3930D4083F52CEd39EB2F20D8"}'
 ```
 Response:
@@ -83,6 +84,7 @@ Signs a Bitcoin transaction using keys derived from an Ethereum address. Require
 ```sh
 curl -X POST http://localhost:5555/sign_transaction \
   -H "Content-Type: application/json" \
+  -H "X-API-Key: your_api_key" \
   -d '{
     "ethereum_address": "742d35Cc6634C0532925a3b844Bc454e4438f44e",
     "inputs": [
@@ -114,7 +116,7 @@ Response:
 - **Networks**: The service supports all Bitcoin networks (Regtest, Testnet, Signet, and Mainnet). The network affects the address format and network parameters.
 - **Security**:
   - The master seed must be provided as an environment variable (`BIP32_SEED`).
-  - Protected endpoints require an API key to be set via the `API_KEY` environment variable.
+  - Protected endpoints require an API key to be set via the `ENCLAVE_API_KEY` environment variable.
   - No direct access to private keys is exposed via the API.
 
 ## Notes:

--- a/src/main.rs
+++ b/src/main.rs
@@ -238,9 +238,13 @@ struct SignTransactionResponse {
     signed_tx: String,
 }
 
+struct AppState {
+    enclave: Arc<SecureEnclave>,
+    api_key: String,
+}
+
 // API validation
-async fn check_api_key(req: &actix_web::HttpRequest) -> bool {
-    let expected_key = std::env::var("API_KEY").unwrap_or_default();
+fn check_api_key(req: &actix_web::HttpRequest, expected_key: &str) -> bool {
     if expected_key.is_empty() {
         return false;
     }
@@ -256,9 +260,16 @@ async fn check_api_key(req: &actix_web::HttpRequest) -> bool {
 
 // API handlers
 async fn derive_address(
-    enclave: web::Data<Arc<SecureEnclave>>,
+    http_req: actix_web::HttpRequest,
+    state: web::Data<AppState>,
     req: web::Json<DeriveAddressRequest>,
 ) -> impl Responder {
+    if !check_api_key(&http_req, &state.api_key) {
+        warn!("Unauthorized derive_address attempt from {:?}", http_req.peer_addr());
+        return HttpResponse::Forbidden().json(serde_json::json!({"error": "Unauthorized"}));
+    }
+
+    let enclave = &state.enclave;
     let evm_addr_bytes = match eth_addr_to_bytes_slice(&req.evm_address) {
         Ok(addr) => addr,
         Err(e) => {
@@ -283,13 +294,15 @@ async fn derive_address(
 
 async fn sign_transaction(
     req: actix_web::HttpRequest,
-    enclave: web::Data<Arc<SecureEnclave>>,
+    state: web::Data<AppState>,
     tx_req: web::Json<SignTransactionRequest>,
 ) -> impl Responder {
-    // Check API key
-    if !check_api_key(&req).await {
-        return HttpResponse::Unauthorized().body("Invalid API key");
+    if !check_api_key(&req, &state.api_key) {
+        warn!("Unauthorized sign_transaction attempt from {:?}", req.peer_addr());
+        return HttpResponse::Forbidden().json(serde_json::json!({"error": "Unauthorized"}));
     }
+
+    let enclave = &state.enclave;
 
     info!(
         "Signing transaction for address: {}, total amount: {} satoshis",
@@ -368,9 +381,9 @@ async fn main() -> std::io::Result<()> {
 
     info!("Starting enclave service...");
 
-    let api_key = std::env::var("API_KEY").unwrap_or_default();
+    let api_key = std::env::var("ENCLAVE_API_KEY").unwrap_or_default();
     if api_key.is_empty() {
-        warn!("WARNING: API_KEY environment variable is not set. Protected endpoints will be inaccessible.");
+        warn!("ENCLAVE_API_KEY environment variable is not set. Protected endpoints will reject requests.");
     }
 
     // Get seed from environment variable
@@ -402,14 +415,17 @@ async fn main() -> std::io::Result<()> {
         }
     };
 
-    let enclave_data = web::Data::new(enclave);
+    let app_state = web::Data::new(AppState {
+        enclave: enclave.clone(),
+        api_key: api_key.clone(),
+    });
 
     let bind_addr = format!("{}:{}", args.host, args.port);
     info!("Binding to {}", bind_addr);
 
     HttpServer::new(move || {
         App::new()
-            .app_data(enclave_data.clone())
+            .app_data(app_state.clone())
             // Public routes
             .route("/derive_address", web::post().to(derive_address))
             .route("/health", web::get().to(health_check))


### PR DESCRIPTION
## Summary
- enforce `X-API-Key` on `/derive_address`
- centralize API key in `AppState`
- document new `ENCLAVE_API_KEY` env var

## Testing
- `cargo test --quiet` *(fails: Could not connect to server)*