### PR TITLE
Add persistent address map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,6 +607,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "flate2"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -965,6 +981,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1058,6 +1080,7 @@ dependencies = [
  "secp256k1 0.29.1",
  "serde",
  "serde_json",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1298,6 +1321,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1488,6 +1524,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitcoin"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,6 +1050,7 @@ name = "network-enclave"
 version = "0.0.6"
 dependencies = [
  "actix-web",
+ "bincode",
  "bitcoin",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 actix-web = "4.9.0"
+bincode = "1"
 bitcoin = "0.31.1"
 chrono = "0.4"
 clap = { version = "4.4.18", features = ["derive"] }
@@ -14,4 +15,4 @@ serde = { version = "1.0.195", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1.0"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-bincode = "1"
+tempfile = "3.20.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ serde = { version = "1.0.195", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1.0"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+bincode = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,13 @@
 use std::collections::HashMap;
 use std::str::FromStr;
-use std::sync::{Arc, Mutex};
+use std::path::PathBuf;
+use std::sync::{Arc, RwLock};
 
 use actix_web::{web, App, HttpResponse, HttpServer, Responder};
 
 use clap::Parser;
 use hex::FromHex;
+use bincode;
 use serde::{Deserialize, Serialize};
 
 use tracing::{debug, error, info, warn};
@@ -39,6 +41,10 @@ struct Args {
     /// Logging level (error, warn, info, debug, trace)
     #[arg(long, default_value = "info")]
     log_level: String,
+
+    /// Path to persist the address map
+    #[arg(long, default_value = "./data/address_map.bin")]
+    address_map_path: String,
 }
 
 fn parse_network(s: &str) -> Result<Network, &'static str> {
@@ -275,7 +281,8 @@ struct EthereumXpubResponse {
 struct AppState {
     enclave: Arc<SecureEnclave>,
     api_key: String,
-    address_map: Mutex<HashMap<String, [u8; 20]>>,
+    address_map: RwLock<HashMap<String, [u8; 20]>>,
+    address_map_path: PathBuf,
 }
 
 // API validation
@@ -321,8 +328,11 @@ async fn derive_address(
             debug!("Derived Bitcoin address: {:?}", address);
             let address_str = address.to_string();
             {
-                let mut map = state.address_map.lock().unwrap();
+                let mut map = state.address_map.write().unwrap();
                 map.insert(address_str.clone(), evm_addr_bytes);
+                if let Ok(serialized) = bincode::serialize(&*map) {
+                    let _ = std::fs::write(&state.address_map_path, serialized);
+                }
             }
             HttpResponse::Ok().json(DeriveAddressResponse {
                 address: address_str,
@@ -355,7 +365,7 @@ async fn sign_transaction(
         .iter()
         .map(|input| {
             let evm = {
-                let map = state.address_map.lock().unwrap();
+                let map = state.address_map.read().unwrap();
                 map.get(&input.address)
                     .cloned()
                     .ok_or_else(|| format!("Unknown address: {}", input.address))
@@ -437,6 +447,25 @@ async fn get_sova_xpub(req: actix_web::HttpRequest, state: web::Data<AppState>) 
     }
 }
 
+async fn get_address_map(req: actix_web::HttpRequest, state: web::Data<AppState>) -> impl Responder {
+    if !check_api_key(&req, &state.api_key) {
+        warn!(
+            "Unauthorized get_address_map attempt from {:?}",
+            req.peer_addr()
+        );
+        return HttpResponse::Forbidden().json(serde_json::json!({"error": "Unauthorized"}));
+    }
+
+    let map = state.address_map.read().unwrap();
+    match serde_json::to_string(&*map) {
+        Ok(body) => HttpResponse::Ok().body(body),
+        Err(e) => {
+            error!("Failed to serialize address map: {}", e);
+            HttpResponse::InternalServerError().body(e.to_string())
+        }
+    }
+}
+
 async fn health_check() -> impl Responder {
     HttpResponse::Ok().json(serde_json::json!({
         "status": "healthy"
@@ -489,10 +518,17 @@ async fn main() -> std::io::Result<()> {
         }
     };
 
+    let map_path = PathBuf::from(&args.address_map_path);
+    let address_map: HashMap<String, [u8; 20]> = match std::fs::read(&map_path) {
+        Ok(bytes) => bincode::deserialize(&bytes).unwrap_or_default(),
+        Err(_) => HashMap::new(),
+    };
+
     let app_state = web::Data::new(AppState {
         enclave: enclave.clone(),
         api_key: api_key.clone(),
-        address_map: Mutex::new(HashMap::new()),
+        address_map: RwLock::new(address_map),
+        address_map_path: map_path,
     });
 
     let bind_addr = format!("{}:{}", args.host, args.port);
@@ -505,6 +541,7 @@ async fn main() -> std::io::Result<()> {
             .route("/health", web::get().to(health_check)) // unprotected
             .route("/sign_transaction", web::post().to(sign_transaction)) // protected
             .route("/sova_xpub", web::get().to(get_sova_xpub)) // protected
+            .route("/address_map", web::get().to(get_address_map)) // protected
     })
     .bind(&bind_addr)?
     .run()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,12 @@
 use std::collections::HashMap;
-use std::str::FromStr;
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 
 use actix_web::{web, App, HttpResponse, HttpServer, Responder};
 
 use clap::Parser;
 use hex::FromHex;
-use bincode;
 use serde::{Deserialize, Serialize};
 
 use tracing::{debug, error, info, warn};
@@ -447,7 +446,10 @@ async fn get_sova_xpub(req: actix_web::HttpRequest, state: web::Data<AppState>) 
     }
 }
 
-async fn get_address_map(req: actix_web::HttpRequest, state: web::Data<AppState>) -> impl Responder {
+async fn get_address_map(
+    req: actix_web::HttpRequest,
+    state: web::Data<AppState>,
+) -> impl Responder {
     if !check_api_key(&req, &state.api_key) {
         warn!(
             "Unauthorized get_address_map attempt from {:?}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -556,7 +556,6 @@ mod tests {
     use bitcoin::Network;
     use std::collections::HashMap;
     use std::fs;
-    use std::path::PathBuf;
     use tempfile::TempDir;
 
     fn create_test_enclave() -> SecureEnclave {


### PR DESCRIPTION
## Summary
- persist address map to disk using bincode
- load map on startup
- expose `/address_map` endpoint to inspect saved entries

## Testing
- `cargo check` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_6866898a60c883288124d0d189685745