### PR TITLE
Update README with address map info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Network Enclave
 
-Network Enclave is a Bitcoin signing service used by the Sova Network that hosts the network master key and provides APIs for derivation of Bitcoin addresses from Ethereum addresses and signing of Bitcoin transactions. This service uses Bitcoin's BIP32 hierarchical deterministic wallets to deterministically derive Bitcoin addresses and keys from Ethereum addresses using a cryptographically secure hash-based approach.
+A Bitcoin signing service used by the Sova Network that hosts the network's master key and provides APIs for derivation of Bitcoin addresses from EVM addresses and signing of Bitcoin transactions. This service uses Bitcoin's BIP32 hierarchical deterministic wallets to deterministically derive Bitcoin addresses and keys from EVM addresses using a cryptographically secure hash-based approach.
 
 ## Features
 
-- Derive Bitcoin addresses from Ethereum addresses
-- Sign Bitcoin transactions using keys derived from Ethereum addresses
+- Derive Bitcoin addresses from EVM addresses
+- Sign Bitcoin transactions
 - Support for multiple Bitcoin networks (Regtest, Testnet, Signet, Mainnet)
 - Secure API key authentication for protected endpoints
 - Domain-separated hashing to prevent cross-protocol attacks
-- Persistent address mapping saved to disk for transaction signing
+- Persistent address mapping saved to disk for easy restarts
 - Collision-resistant address derivation with 2^108 security level
 
 ## Getting Started
@@ -82,7 +82,7 @@ Response:
 ```
 
 ### 2. Derive Bitcoin Address (Protected)
-Derives a Bitcoin address from an Ethereum address. Requires the `X-API-Key` header.
+Derives a Bitcoin address from an EVM address. Requires the `X-API-Key` header.
 ```sh
 curl -X POST http://localhost:5555/derive_address \
   -H "Content-Type: application/json" \
@@ -96,8 +96,8 @@ Response:
 }
 ```
 
-### 3. Get Ethereum Extended Public Key (Protected)
-Returns the ethereum-level extended public key (m/44'/0') for use by network nodes. This is the public key used for deterministic address derivation.
+### 3. Get EVM Extended Public Key (Protected)
+Returns the EVM-level extended public key (m/44'/0') for use by network nodes. This is the public key used for deterministic address derivation.
 ```sh
 curl -X GET http://localhost:5555/sova_xpub \
   -H "X-API-Key: api_key_here"
@@ -111,7 +111,7 @@ Response:
 ```
 
 ### 4. Sign Transaction (Protected)
-Signs a Bitcoin transaction using keys derived from Ethereum addresses. The service must have previously derived the addresses via `/derive_address` to maintain the mapping between Bitcoin addresses and Ethereum addresses.
+Signs a Bitcoin transaction using keys derived from EVM addresses. The service must have previously derived the addresses via `/derive_address` to maintain the mapping between Bitcoin addresses and EVM addresses.
 ```sh
 curl -X POST http://localhost:5555/sign_transaction \
   -H "Content-Type: application/json" \
@@ -140,7 +140,7 @@ Response:
   "signed_tx": "02000000000101b2a1f0e9..."
 }
 ### 5. Get Address Map (Protected)
-Returns the current mapping of Bitcoin addresses to their source Ethereum addresses.
+Returns the current mapping of Bitcoin addresses to their source EVM addresses.
 ```sh
 curl -X GET http://localhost:5555/address_map 
   -H "X-API-Key: api_key_here"
@@ -153,38 +153,36 @@ Response:
 ## Implementation Details
 
 ### Key Derivation Algorithm
-The service uses a cryptographically secure hash-based approach to derive Bitcoin keys from Ethereum addresses:
+The service uses a cryptographically secure hash-based approach to derive Bitcoin keys from EVM addresses:
 
-1. **Domain Separation**: Each Ethereum address is hashed with a domain tag to prevent cross-protocol attacks
-2. **SHA256 Hashing**: The combination of domain tag + Ethereum address is hashed with SHA256
+1. **Domain Separation**: Each EVM address is hashed with a domain tag to prevent cross-protocol attacks
+2. **SHA256 Hashing**: The combination of domain tag + EVM address is hashed with SHA256
 3. **BIP32 Path Generation**: The 256-bit hash is split into 7 chunks of 4 bytes each, creating a 9-level derivation path:
-   - `m/44'/0'` - Base ethereum extended key path (hardened)
+   - `m/44'/0'` - Base EVM extended key path (hardened)
    - 7 additional non-hardened levels derived from hash chunks
 
 ### Security Properties
-- **Collision Resistance**: ~2^108 operations needed to find two Ethereum addresses that map to the same Bitcoin address
+- **Collision Resistance**: ~2^108 operations needed to find two EVM addresses that map to the same Bitcoin address
 - **Entropy Utilization**: 217 out of 256 bits (85%) of hash entropy used in derivation
-- **Domain Separation**: Prevents attacks from other systems using the same Ethereum addresses
+- **Domain Separation**: Prevents attacks from other systems using the same EVM addresses
 - **Non-hardened Derivation**: Allows public key derivation without private key access
 
 ### Technical Specifications
 - **Address Type**: All derived addresses are P2WPKH (Pay-to-Witness-Public-Key-Hash, SegWit) addresses
 - **Networks**: Supports all Bitcoin networks (Regtest, Testnet, Signet, and Mainnet)
-- **Derivation Path**: `m/44'/0'/hash_chunk_1/hash_chunk_2/.../hash_chunk_7` where hash chunks are derived from SHA256(domain_tag || ethereum_address)
+- **Derivation Path**: `m/44'/0'/hash_chunk_1/hash_chunk_2/.../hash_chunk_7` where hash chunks are derived from SHA256(domain_tag || EVM_address)
+- **Address Map Persistence**: Address mappings are saved to disk (see `--address-map-path`); ensure the file persists across restarts
 
 ### Security Considerations
 - **Master Seed Security**: The `BIP32_SEED` must be cryptographically secure (256+ bits of entropy) and kept private
 - **API Key Protection**: Use strong API keys and ensure HTTPS in production
-- **Address Mapping**: The service persists the mapping between derived Bitcoin addresses and Ethereum addresses to the file specified by `--address-map-path`
 - **Network Validation**: All output addresses are validated against the specified Bitcoin network
 
 ### Integration with Sova Network
-1. **Setup**: Deploy the enclave and get the ethereum extended public key via `/sova_xpub`
-2. **Network Configuration**: Configure Sova nodes with the ethereum xpub as `SOVA_DERIVATION_XPUB`
-3. **Address Derivation**: Nodes can derive Bitcoin addresses locally using the public key
-4. **Transaction Signing**: When spending is needed, nodes call the enclave's `/sign_transaction` endpoint
+1. **Setup**: Deploy the service and get the extended public key via `/sova_xpub` route
+3. **Address Derivation**: Nodes can derive Bitcoin addresses locally using an extended public key (`SOVA_DERIVATION_XPUB`)
+4. **Transaction Signing**: When spending is needed, the sequencer will call the enclave's `/sign_transaction` endpoint
 
 ### Limitations
 - **Transaction Validation**: The API does not validate that transaction inputs can actually be spent - caller must ensure inputs are valid
 - **Address Type Constraints**: Only P2WPKH addresses are currently supported
-- **Address Map Persistence**: Address mappings are saved to disk (see `--address-map-path`); ensure the file persists across restarts

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Network Enclave is a Bitcoin signing service used by the Sova Network that hosts
 - Support for multiple Bitcoin networks (Regtest, Testnet, Signet, Mainnet)
 - Secure API key authentication for protected endpoints
 - Domain-separated hashing to prevent cross-protocol attacks
+- Persistent address mapping saved to disk for transaction signing
 - Collision-resistant address derivation with 2^108 security level
 
 ## Getting Started
@@ -59,6 +60,7 @@ The service supports the following command-line arguments:
 - `--port` - Port to listen on (default: 5555)
 - `--network` - Bitcoin network to use (options: regtest, testnet, signet, mainnet; default: regtest)
 - `--log-level` - Logging level (options: error, warn, info, debug, trace; default: info)
+- `--address-map-path` - File path for persisting the address map (default: ./data/address_map.bin)
 
 Example with custom arguments:
 ```sh
@@ -137,6 +139,15 @@ Response:
 {
   "signed_tx": "02000000000101b2a1f0e9..."
 }
+### 5. Get Address Map (Protected)
+Returns the current mapping of Bitcoin addresses to their source Ethereum addresses.
+```sh
+curl -X GET http://localhost:5555/address_map 
+  -H "X-API-Key: api_key_here"
+```
+Response:
+```json
+{"bcrt1q...":"0xf39f..."}
 ```
 
 ## Implementation Details
@@ -164,7 +175,7 @@ The service uses a cryptographically secure hash-based approach to derive Bitcoi
 ### Security Considerations
 - **Master Seed Security**: The `BIP32_SEED` must be cryptographically secure (256+ bits of entropy) and kept private
 - **API Key Protection**: Use strong API keys and ensure HTTPS in production
-- **Address Mapping**: The service maintains an in-memory mapping between Bitcoin addresses and Ethereum addresses for transaction signing
+- **Address Mapping**: The service persists the mapping between derived Bitcoin addresses and Ethereum addresses to the file specified by `--address-map-path`
 - **Network Validation**: All output addresses are validated against the specified Bitcoin network
 
 ### Integration with Sova Network
@@ -176,4 +187,4 @@ The service uses a cryptographically secure hash-based approach to derive Bitcoi
 ### Limitations
 - **Transaction Validation**: The API does not validate that transaction inputs can actually be spent - caller must ensure inputs are valid
 - **Address Type Constraints**: Only P2WPKH addresses are currently supported
-- **In-Memory State**: Address mappings are lost on service restart
+- **Address Map Persistence**: Address mappings are saved to disk (see `--address-map-path`); ensure the file persists across restarts


### PR DESCRIPTION
## Summary
- note persistent address map in features
- document `--address-map-path` argument
- add `/address_map` endpoint docs
- clarify address map persistence in security and limitations

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68669703efb8832880fc31dfc9290c14